### PR TITLE
bump gunicorn to v23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ backtrader==1.9.78.123
 beautifulsoup4==4.12.3
 flask==3.0
 Flask-WTF==1.2.1
-gunicorn==22.0.0
+gunicorn==23.0.0
 openapi-python-client==0.19.1
 selenium==4.21.0
 talipp==2.2.0


### PR DESCRIPTION
Fix for [CVE-2024-1135](https://github.com/advisories/GHSA-w3h3-4rj7-4ph4) in gunicorn.